### PR TITLE
fix: update to latest blender 4 version and use blender offical mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,11 @@ RUN cd /opt &&\
 
 # Install Blender
 ENV BLENDER_4=/opt/blender/blender
-RUN wget https://ftp.nluug.nl/pub/graphics/blender/release/Blender4.3/blender-4.5.5-linux-x64.tar.xz
+RUN wget https://download.blender.org/release/Blender4.5/blender-4.5.8-linux-x64.tar.xz
 RUN apt-get install xz-utils -y &&\
-    tar -xvf blender-4.3.2-linux-x64.tar.xz &&\
-    mv blender-4.3.2-linux-x64 /opt/blender &&\
-    rm blender-4.3.2-linux-x64.tar.xz
+    tar -xvf blender-4.5.8-linux-x64.tar.xz &&\
+    mv blender-4.5.8-linux-x64 /opt/blender &&\
+    rm blender-4.5.8-linux-x64.tar.xz
 
 # Install Blender Dependencies
 RUN apt-get install -y \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ EXPORT_SOURCE := $(shell find tools/mesh_export/ -type f -name '*.py' | sort)
 # t3d_meshes
 ###
 
-# BLENDER_4 := /home/james/Blender/blender-4.0.2-linux-x64/blender
+# BLENDER_4 := /home/james/Blender/blender-4.5.8-linux-x64/blender
 
 MESH_SOURCES := $(shell find assets/meshes -type f -name '*.blend' | sort)
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ A new original N64 game
 
 Use [libdragon](https://github.com/DragonMinded/libdragon) to build the project. You should use the preview branch to get opengl (sha 1559f4a02828508bf31d6c63252f20d887f32be8)
 
-You need to specify the location of blender 4.0.2 using en enviroment variable
+You need to specify the location of blender 4.5.8 using en enviroment variable
 
 ```
-export BLENDER_4=/home/james/Blender/blender-4.0.2-linux-x64/blender
+export BLENDER_4=/home/james/Blender/blender-4.5.8-linux-x64/blender
 ```
 replace the location of blender where it is installed on your machine.
 


### PR DESCRIPTION
This pull request updates the project to use Blender version 4.5.8 instead of 4.0.2 or earlier 4.5.x versions. The changes ensure that all references, installation steps, and documentation are consistent with the new Blender version.

**Blender version update:**

* Updated the Blender download URL and installation steps in the `Dockerfile` to use Blender 4.5.8 instead of 4.0.2, 4.3.2 or 4.5.5.
* Updated the commented example `BLENDER_4` path in the `Makefile` to reference Blender 4.5.8.
* Updated the documentation in `README.md` to instruct users to set the `BLENDER_4` environment variable to the Blender 4.5.8 binary path.